### PR TITLE
Fix minors

### DIFF
--- a/PianoManager/HunPianoManager.py
+++ b/PianoManager/HunPianoManager.py
@@ -11,7 +11,6 @@ from PianoManager.main_NewUser import NewUser
 
 
 class MainWindow(QMainWindow):
-
     def __init__(self):
         QMainWindow.__init__(self)
         self.setWindowTitle("Piano Manager")

--- a/PianoManager/main_NewUser.py
+++ b/PianoManager/main_NewUser.py
@@ -35,12 +35,15 @@ class NewUser(QStackedWidget):
         # # Connect pages to switch each others
         # New User 1
         new_user_1_page.ui.buttonRight.clicked.connect(partial(self.switch_page, 1))
+        new_user_1_page.ui.editName.returnPressed.connect(partial(self.switch_page, 1))
         # New User 2
         new_user_2_page.ui.buttonLeft.clicked.connect(partial(self.switch_page, 0))
         new_user_2_page.ui.buttonRight.clicked.connect(partial(self.switch_page, 2))
+        new_user_2_page.ui.editContact3.returnPressed.connect(partial(self.switch_page, 2))
         # New User 3
         new_user_3_page.ui.buttonLeft.clicked.connect(partial(self.switch_page, 1))
         new_user_3_page.ui.buttonRight.clicked.connect(partial(self.switch_page, 3))
+        new_user_3_page.ui.editID.returnPressed.connect(partial(self.switch_page, 3))
         # New User Check
         new_user_check_page.ui.buttonLeft.clicked.connect(partial(self.switch_page, 2))
         new_user_check_page.ui.buttonReturn.clicked.connect(partial(self.switch_page, 0))

--- a/PianoManager/main_NewUser3.py
+++ b/PianoManager/main_NewUser3.py
@@ -9,6 +9,8 @@ from PianoManager.reader_for_test import TestDatabaseReader
 
 
 class NewUser3(QWidget):
+    free_pass = "201912041"
+
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
 
@@ -37,10 +39,12 @@ class NewUser3(QWidget):
         self.ui.buttonLeft.setEnabled(True)
         self.ui.buttonRight.setEnabled(True)
         self.ui.editID.setText(self.dbReader.get_current_data("ID"))
+        self.ui.labelWarning.show()
         self.ui.labelError.hide()
 
     def clear_page(self):
-        if self.ui.editID.text() == "":
+        user_id = self.ui.editID.text()
+        if len(user_id) != 10 and user_id != self.free_pass:
             self.ui.labelWarning.hide()
             self.ui.labelError.show()
             self.error_animation()


### PR DESCRIPTION
학번이 없을 시의 안내 문구가 출력되지 않는 오류
학번이 없는 학내 구성원을 나타내기 위한 임시 학번 설정
등록 시 각 페이지의 마지막 입력창에서 엔터를 누르면 다음 페이지로 이동하도록 수정